### PR TITLE
feat: allow to use jaas config file to set OAuth configuration

### DIFF
--- a/kafka-oauth/README.md
+++ b/kafka-oauth/README.md
@@ -27,8 +27,9 @@ limitations under the License.
 #### Config Files
 - Create a properties file for your Broker OAuth client {broker-configuration.properties}.
 - The file should contain the following properties:
-- NOTE: you will need to update the oauth.server.client.secret to be your client secret!!!!!
-
+- NOTES: 
+    - you will need to update the oauth.server.client.secret to be your client secret!!!!!
+    - you can pass this properties under the kafka_server_jaas.conf
 
         oauth.server.base.uri=http://localhost:8080/auth/realms/master/protocol/openid-connect
         oauth.server.token.endpoint.path=/token
@@ -43,10 +44,18 @@ limitations under the License.
 
 - Create a config file for your JAAS security {kafka_server_jaas.conf}
     - The file must contain the following:
-
+    - NOTE: the properties started by oauth.server only needed if you don't want to user the broker-configuration.properties file!
     
             KafkaServer {
-                org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ;
+                org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required 
+                oauth.server.base.uri="http://localhost:8080/auth/realms/master/protocol/openid-connect"
+                oauth.server.token.endpoint.path="/token"
+                oauth.server.introspection.endpoint.path="/token/introspect"
+                oauth.server.client.id="kafka-broker"
+                oauth.server.client.secret="4ce54cfb-f359-4400-bd8e-810a1af10f71"
+                oauth.server.grant.type="client_credentials"
+                oauth.server.scopes="test"
+                oauth.server.accept.unsecure.server="true";
             };
 
 

--- a/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthAuthenticateCallbackHandler.java
+++ b/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthAuthenticateCallbackHandler.java
@@ -128,6 +128,8 @@ public abstract class OAuthAuthenticateCallbackHandler<T> implements Authenticat
 			if (jaasConfigEntries.size() == 1 && jaasConfigEntries.get(0) != null) {
 				this.moduleOptions = Collections.unmodifiableMap(
 						(Map<String, String>) jaasConfigEntries.get(0).getOptions());
+				//Configure OAuthService using the JAAS file properties
+				this.oauthService.setOAuthConfiguration(moduleOptions);
 				// the handle has been configured
 				configured = true;
 			} else {

--- a/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthConfiguration.java
+++ b/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthConfiguration.java
@@ -22,6 +22,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -319,6 +321,64 @@ public class OAuthConfiguration {
         }
 
         return true;
+    }
+
+    public void setConfigurationFromJaasConfigEntries(Map<String,String> jaasConfigEntries) {
+        //validate the parameters
+        Objects.requireNonNull(jaasConfigEntries);
+
+        // get the OAuth server base Uri
+        String defaultBaseServerUri = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_BASE_URI, "");
+        if (!Utils.isNullOrEmpty(defaultBaseServerUri)) {
+            this.baseServerUri = defaultBaseServerUri;
+        }
+
+        // get the OAuth server token path
+        String defaultTokenEndpointPath = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_TOKEN_ENDPOINT_PATH, "");
+        if (!Utils.isNullOrEmpty(defaultTokenEndpointPath)) {
+            this.tokenEndpointPath = defaultTokenEndpointPath;
+        }
+
+        // get the OAuth server introspection endpoint path
+        String defaultIntrospectionEndpointPath = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_INTROSPECTION_ENDPOINT_PATH, "");
+        if (!Utils.isNullOrEmpty(defaultIntrospectionEndpointPath)) {
+            this.introspectionEndpointPath = defaultIntrospectionEndpointPath;
+        }
+
+        // get the OAuth server client id
+        String defaultClientId = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_CLIENT_ID, "");
+        if (!Utils.isNullOrEmpty(defaultClientId)) {
+            this.clientId = defaultClientId;
+        }
+
+        // get the OAuth server client secret
+        String defaultClientSecret = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_CLIENT_SECRET, "");
+        if (!Utils.isNullOrEmpty(defaultClientSecret)) {
+            this.clientSecret = defaultClientSecret;
+        }
+
+        // get the OAuth server grant type
+        String defaultGrantType = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_GRANT_TYPE, "");
+        if (!Utils.isNullOrEmpty(defaultGrantType)) {
+            this.grantType = defaultGrantType;
+        }
+
+        // get the OAuth server scopes
+        String defaultScopes = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_SCOPES, "");
+        if (!Utils.isNullOrEmpty(defaultScopes)) {
+            this.scopes = defaultScopes;
+        }
+
+        // get the OAuth server unsecure server
+        String defaultUnsecureServer = jaasConfigEntries.getOrDefault(KAFKA_OAUTH_SERVER_ACCEPT_UNSECURE_SERVER, "");
+        if (!Utils.isNullOrEmpty(defaultUnsecureServer)) {
+            this.unsecureServer = Boolean.valueOf(defaultUnsecureServer);
+        }
+
+        //check if the configuration remains valid
+        if (!this.isValid()) {
+            throw new IllegalStateException("Configuration entries at jaas configuration file are invalid.");
+        }
     }
 
     //endregion

--- a/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthService.java
+++ b/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthService.java
@@ -16,6 +16,7 @@ limitations under the License.
 package com.bfm.kafka.security.oauthbearer;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * This interface defines services from an OAuth Server that are needed for lib-kafka-oauth
@@ -43,4 +44,6 @@ public interface OAuthService {
      * @return the o auth configuration
      */
     OAuthConfiguration getOAuthConfiguration();
+
+    void setOAuthConfiguration(Map<String, String> jaasConfigEntries);
 }

--- a/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthServiceImpl.java
+++ b/kafka-oauth/src/main/java/com/bfm/kafka/security/oauthbearer/OAuthServiceImpl.java
@@ -66,6 +66,16 @@ public class OAuthServiceImpl implements OAuthService {
 		return this.oauthConfiguration;
 	}
 
+	@Override
+	public void setOAuthConfiguration(Map<String, String> jaasConfigEntries) {
+		try {
+			//validate parameters
+			Objects.requireNonNull(jaasConfigEntries);
+			this.oauthConfiguration.setConfigurationFromJaasConfigEntries(jaasConfigEntries);
+		} catch (RuntimeException e) {
+			log.warn("Error on trying to configure oauth using jaas configuration entries. Using environment or properties file configuration");
+		}
+	}
 
 	//endregion
 

--- a/kafka-oauth/src/test/java/com/bfm/kafka/security/oauthbearer/OAuthConfigurationTests.java
+++ b/kafka-oauth/src/test/java/com/bfm/kafka/security/oauthbearer/OAuthConfigurationTests.java
@@ -15,9 +15,13 @@ limitations under the License.
 */
 package com.bfm.kafka.security.oauthbearer;
 
+import org.apache.kafka.common.protocol.types.Field;
 import org.junit.Test;
 
-import static org.junit.Assert.assertNotNull;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.Assert.*;
 
 public class OAuthConfigurationTests {
 
@@ -28,5 +32,40 @@ public class OAuthConfigurationTests {
 
         // assert
         assertNotNull(oauthConfiguration);
+    }
+
+    @Test
+    public void testSetConfigurationUsingJaasConfiguratioFile(){
+        Map<String, String> jaasConfigurationEntries = new TreeMap<>();
+
+        String serverBaseUri = "http://localhost:8080/auth/realms/master1/protocol/openid-connect";
+        String serverEndpointPath = "/token1";
+        String serverIntrospectionEndpointPath = "/token1/introspect";
+        String serverClientId = "test-consumer-1";
+        String serverClientSecret = "7b3c23e1-8909-489e-bf4a-64a84abb197e";
+        String serverGrantType = "client_credentials";
+        String serverScopes = "test-1";
+        String serverAcceptUnsecureServer = "false";
+
+        jaasConfigurationEntries.put("oauth.server.base.uri", serverBaseUri);
+        jaasConfigurationEntries.put("oauth.server.token.endpoint.path", serverEndpointPath);
+        jaasConfigurationEntries.put("oauth.server.introspection.endpoint.path", serverIntrospectionEndpointPath);
+        jaasConfigurationEntries.put("oauth.server.client.id", serverClientId);
+        jaasConfigurationEntries.put("oauth.server.client.secret", serverClientSecret);
+        jaasConfigurationEntries.put("oauth.server.grant.type", serverGrantType);
+        jaasConfigurationEntries.put("oauth.server.scopes", serverScopes);
+        jaasConfigurationEntries.put("oauth.server.accept.unsecure.server", serverAcceptUnsecureServer);
+
+        OAuthConfiguration oauthConfiguration = new OAuthConfiguration();
+        oauthConfiguration.setConfigurationFromJaasConfigEntries(jaasConfigurationEntries);
+
+        assertTrue(oauthConfiguration.getBaseServerUri().equals(serverBaseUri));
+        assertTrue(oauthConfiguration.getTokenEndpointPath().equals(serverEndpointPath));
+        assertTrue(oauthConfiguration.getIntrospectionEndpointPath().equals(serverIntrospectionEndpointPath));
+        assertTrue(oauthConfiguration.getClientId().equals(serverClientId));
+        assertTrue(oauthConfiguration.getClientSecret().equals(serverClientSecret));
+        assertTrue(oauthConfiguration.getGrantType().equals(serverGrantType));
+        assertTrue(oauthConfiguration.getScopes().equals(serverScopes));
+        assertFalse(oauthConfiguration.getUnsecureServer());
     }
 }


### PR DESCRIPTION
- Allow to use the JAAS configuration file to set all OAuth configuration options.

Example: instead you create the file `broker-configuration.properties` or use environment variables you can set the configurations like this:

```
KafkaServer {
    org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required 
    oauth.server.base.uri="http://localhost:8080/auth/realms/master/protocol/openid-connect"
    oauth.server.token.endpoint.path="/token"
    oauth.server.introspection.endpoint.path="/token/introspect"
    oauth.server.client.id="kafka-broker"
    oauth.server.client.secret="4ce54cfb-f359-4400-bd8e-810a1af10f71"
    oauth.server.grant.type="client_credentials"
    oauth.server.scopes="test"
    oauth.server.accept.unsecure.server="true";
};
```

or this for the Client

```
KafkaClient {
    org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required 
    oauth.server.base.uri="http://localhost:8080/auth/realms/master/protocol/openid-connect"
    oauth.server.token.endpoint.path="/token"
    oauth.server.client.id="kafka-broker"
    oauth.server.client.secret="4ce54cfb-f359-4400-bd8e-810a1af10f71"
    oauth.server.grant.type="client_credentials"
    oauth.server.accept.unsecure.server="true";
}
```